### PR TITLE
Fix warning and indentation in test

### DIFF
--- a/Sources/KeyCodes/KeyCodes.swift
+++ b/Sources/KeyCodes/KeyCodes.swift
@@ -53,15 +53,21 @@ final public class KeyCodes {
   }
 
   public func mapKeyCodes(from inputSource: TISInputSource) throws -> VirtualKeyContainer {
-    var storage = [VirtualKey]()
+    var storage = [String: VirtualKey]()
     for intValue in 0..<128 {
       for modifier in VirtualModifierKey.allCases {
         let value = try value(for: intValue, modifiers: [modifier], from: inputSource)
-        storage.append(value)
+        storage[value.displayValue.withModifiers([modifier]).prefix(.displayValue)] = value
+        storage[value.rawValue.withModifiers([modifier]).prefix(.rawValue)] = value
+        storage[value.keyCode.withModifiers([modifier]).prefix(.keyCode)] = value
       }
 
-      let value = try value(for: intValue, modifiers: [.option, .shift], from: inputSource)
-      storage.append(value)
+      let modifiers: [VirtualModifierKey] = [.option, .shift]
+      let value = try value(for: intValue, modifiers: modifiers, from: inputSource)
+
+      storage[value.displayValue.withModifiers(modifiers).prefix(.displayValue)] = value
+      storage[value.rawValue.withModifiers(modifiers).prefix(.rawValue)] = value
+      storage[value.keyCode.withModifiers(modifiers).prefix(.keyCode)] = value
     }
 
     return VirtualKeyContainer(storage)

--- a/Tests/KeyCodesTests/KeyCodesTest.swift
+++ b/Tests/KeyCodesTests/KeyCodesTest.swift
@@ -38,16 +38,16 @@ final class KeyCodesTest: XCTestCase {
   func testMapKeyCodesFromInputSource() async throws {
     let keyCodes = KeyCodes()
     let input = try InputSourceController().currentInputSource()
-    let result = try await keyCodes.mapKeyCodes(from: input.source)
+    let result = try keyCodes.mapKeyCodes(from: input.source)
 
     XCTAssertEqual(result.valueForKeyCode(0, modifier: .clear)?.rawValue, "a")
     XCTAssertEqual(result.valueForKeyCode(0, modifier: .shift)?.rawValue, "A")
 
-      XCTAssertEqual(result.valueForString("a", modifier: .clear, matchDisplayValue: true)?.keyCode, 0)
-      XCTAssertEqual(result.valueForString("a", modifier: .clear, matchDisplayValue: true)?.modifiers, [.clear])
+    XCTAssertEqual(result.valueForString("a", modifier: .clear, matchDisplayValue: true)?.keyCode, 0)
+    XCTAssertEqual(result.valueForString("a", modifier: .clear, matchDisplayValue: true)?.modifiers, [.clear])
 
-      XCTAssertEqual(result.valueForString("A", modifier: .shift, matchDisplayValue: true)?.keyCode, 0)
-      XCTAssertEqual(result.valueForString("A", modifier: .shift, matchDisplayValue: true)?.modifiers, [.shift])
+    XCTAssertEqual(result.valueForString("A", modifier: .shift, matchDisplayValue: true)?.keyCode, 0)
+    XCTAssertEqual(result.valueForString("A", modifier: .shift, matchDisplayValue: true)?.modifiers, [.shift])
   }
 
   func testSystemKeys() throws {
@@ -191,7 +191,7 @@ final class KeyCodesTest: XCTestCase {
     if !identifierIsInstalled { try controller.install(identifier) }
 
     let input = try controller.select(identifier)
-    
+
     XCTAssertEqual("@", try keyCodes.value(for: 42, modifiers: [], from: input.source).displayValue)
     XCTAssertEqual("+", try keyCodes.value(for: 27, modifiers: [], from: input.source).displayValue)
     XCTAssertEqual(",", try keyCodes.value(for: 43, modifiers: [], from: input.source).displayValue)


### PR DESCRIPTION
Refactor VirtualKeyContainer to hold a dictionary instead of an array

To improve lookup performance, `VirtualKeyContainer` is now backed by
a dictionary instead of an array. This means that lookup will happen
in constant time because keys are computed when mapping the current
input source. Memory usage might be slightly bigger and mapping
might take slightly longer, but seeing as index usually happens
when the input changes, having faster lookup takes precedence.

This can be improved upon in the future.